### PR TITLE
show error if piano resource fails to load

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -60,3 +60,11 @@ li > span {
 .Header .Navigation a {
   margin-right: 1rem;
 }
+
+.ErrorBanner {
+  padding: 1rem;
+  padding-bottom: 1rem;
+  border: thin solid #ff4444;
+  border-radius: 3px;
+  margin-bottom: 1rem;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -3,20 +3,49 @@ import { connect } from "react-redux";
 import "./App.css";
 import Header from "./components/Header";
 import Router from "./components/Router";
+import ErrorBanner from "./components/shared/ErrorBanner";
 import { setRoute } from "./router";
+import { loadPiano } from "../src/player";
+
 import { Note } from "tonal";
 
 class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      loadPianoError: null,
+    };
+  }
+
+  componentDidMount() {
+    if (!window.Soundfont) {
+      setTimeout(() => this.loadPianoResource(window.Soundfont), 1000);
+    }
+  }
+
+  loadPianoResource(soundfont) {
+    loadPiano(soundfont)
+      .catch(error => this.setState({ loadPianoError: error }));
+  }
+
   render() {
     const { path, route } = this.props;
     const handleTonicChange = midi => {
       const tonic = Note.fromMidi(midi);
       setRoute(tonic, route.path, route.id);
     };
+
     return (
       <div className="container App">
+        {
+          this.state.loadPianoError &&
+          <ErrorBanner>
+            <h4>Oh No...</h4>
+            <p>Failed to load piano player resource. Please turn off any active adblock extensions.</p>
+          </ErrorBanner>
+        }
         <Header route={route} onTonicChange={handleTonicChange} />
-        {<Router path={path} route={route} />}
+        <Router path={path} route={route} />
       </div>
     );
   }

--- a/src/components/shared/ErrorBanner.js
+++ b/src/components/shared/ErrorBanner.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default ({ children }) => (
+  <div className="ErrorBanner">{children}</div>
+);

--- a/src/player.js
+++ b/src/player.js
@@ -2,20 +2,13 @@ import { Note, transpose } from "tonal";
 const ac = new AudioContext();
 let piano = null;
 
-const loadPiano = Soundfont => {
+export const loadPiano = Soundfont => {
   console.log("Loading...");
-  if (Soundfont === undefined) {
-    console.log("Load piano retry");
-    setTimeout(() => loadPiano(window.Soundfont), 1000);
-  } else {
-    Soundfont.instrument(ac, "acoustic_grand_piano").then(inst => {
-      console.log("Piano loaded!");
-      piano = inst;
-    });
-  }
+  return Soundfont.instrument(ac, "acoustic_grand_piano").then(inst => {
+    console.log("Piano loaded!");
+    piano = inst;
+  });
 };
-
-loadPiano(window.Soundfont);
 
 const centered = tonic => {
   const pc = Note.pc(tonic);


### PR DESCRIPTION
The piano resource will fail to load if an adblock extension is running (and may happen other times, but I've only had trouble while adblock is active). 
These changes add an ErrorBanner on the top of the screen if it fails to load. I thought it would be better to provide the user with some visual indicator, especially since adblock extensions are pretty common.

<img width="923" alt="screen shot 2018-10-08 at 7 50 59 pm" src="https://user-images.githubusercontent.com/5976642/46639466-2ee07500-cb34-11e8-8686-98cb959af72a.png">

Made changes to `player.js` and `App.js`. Now we're loading piano inside `App.componentDidMount()` and updating error UI there. Wasn't sure how else to react to the failed load.

Let me know if you like/dislike this!

